### PR TITLE
Adding changes for saving topic distributions for each document

### DIFF
--- a/src/gaussianlda/trainer/chol_alias.py
+++ b/src/gaussianlda/trainer/chol_alias.py
@@ -635,6 +635,7 @@ class GaussianLDAAliasTrainer:
             ("sum_squared_table_customers", self.sum_squared_table_customers),
             ("table_cholesky_ltriangular_mat", self.table_cholesky_ltriangular_mat.np),
             ("vocab_embeddings", self.vocab_embeddings),
+            ("table_counts_per_doc", self.table_counts_per_doc),
         ]:
             with open(os.path.join(self.save_path, "{}.pkl".format(name)), "wb") as f:
                 pickle.dump(data, f)

--- a/src/gaussianlda/trainer/chol_alias.py
+++ b/src/gaussianlda/trainer/chol_alias.py
@@ -350,7 +350,7 @@ class GaussianLDAAliasTrainer:
                   )
         return logprob
 
-    def sample(self, num_iterations):
+    def sample(self, num_iterations, conv_wait_cnt = 10):
         """
         for num_iters:
             for each customer
@@ -366,7 +366,7 @@ class GaussianLDAAliasTrainer:
 
         avg_ll_list = []
         conv_threshold = 0.01
-        conv_wait_cnt = 10
+        
 
         if self.show_topics is not None:
             print("Topics after initialization")

--- a/src/gaussianlda/utils.py
+++ b/src/gaussianlda/utils.py
@@ -100,7 +100,7 @@ class BatchedRands:
     """
     def __init__(self, batch_size=1000):
         self.batch_size = batch_size
-        self.rng = default_rng()
+        self.rng = default_rng(1234)
         self._it = iter(self)
 
     def __iter__(self):

--- a/src/gaussianlda/utils.py
+++ b/src/gaussianlda/utils.py
@@ -140,7 +140,7 @@ class BatchedRandInts:
     def __init__(self, high, batch_size=1000):
         self.high = high
         self.batch_size = batch_size
-        self.rng = default_rng()
+        self.rng = default_rng(1234)
         self._new_batch()
 
     def _new_batch(self):


### PR DESCRIPTION
Dear Markgw, we are working on a research project which uses Gaussian LDA for hierarchical clustering and we need the mapping information between documents and topics for this purpose. so we are saving the table_counts_per_doc object for the same and I hope this will be helpful for everyone to analyze the topic distributions for each document.